### PR TITLE
Add GitHub workflow to build and push Docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/eric2788/mcp-bridge:latest
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/eric2788/mcp-bridge
+          tags: |
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
+            type=raw,value={{branch}},enable=${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -31,5 +41,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/eric2788/mcp-bridge:latest
+          tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install
 
 # install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-RUN export PATH=/root/.local/bin:$PATH
+ENV PATH=/root/.local/bin:$PATH
 
 COPY pyproject.toml .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install
 
 # install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-RUN . $HOME/.local/bin/env
+RUN export PATH=$HOME/.local/bin:$PATH
 
 COPY pyproject.toml .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 ARG TARGETPLATFORM
 FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 
-# install curl, qemu-user-static, and nodejs
-RUN apt-get update && apt-get install -y --no-install-recommends curl qemu-user-static
- curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
+# install curl, qemu-user-static
+RUN apt-get update && apt-get install -y curl qemu-user-static
+
+# install nodejs
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
 
 # install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install
 
 # install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-RUN export PATH=$HOME/.local/bin:$PATH
+ENV PATH=$HOME/.local/bin:$PATH
 
 COPY pyproject.toml .
 
@@ -17,7 +17,7 @@ COPY pyproject.toml .
 COPY mcp_bridge/__init__.py mcp_bridge/__init__.py
 COPY README.md README.md
 
-RUN $HOME/.local/bin/uv sync
+RUN uv sync
 
 COPY mcp_bridge mcp_bridge
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install
 
 # install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-RUN source $HOME/.local/bin/env
+RUN . $HOME/.local/bin/env
 
 COPY pyproject.toml .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 ARG TARGETPLATFORM
 FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 
-# install uv, curl, nodejs, and qemu-user-static
-RUN apt-get update && apt-get install -y --no-install-recommends uv curl qemu-user-static && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs
+# install curl, qemu-user-static, and nodejs
+RUN apt-get update && apt-get install -y --no-install-recommends curl qemu-user-static
+ curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
+
+# install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 COPY pyproject.toml .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,14 @@
 ARG TARGETPLATFORM
 FROM --platform=$TARGETPLATFORM python:3.12-slim
-USER root
+
 # install curl
 RUN apt-get update && apt-get install -y git curl
 
 # install nodejs
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
 
-# install uv with awareness of target architecture
-ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_ARCH=aarch64 sh; \
-    else \
-      curl -LsSf https://astral.sh/uv/install.sh | sh; \
-    fi
-ENV PATH=/root/.local/bin:$PATH
+# install uv to run stdio clients (uvx)
+RUN pip install --no-cache-dir uv
 
 COPY pyproject.toml .
 
@@ -29,4 +23,4 @@ COPY mcp_bridge mcp_bridge
 EXPOSE 8000
 
 WORKDIR /mcp_bridge
-ENTRYPOINT ["/root/.local/bin/uv", "run", "main.py"]
+ENTRYPOINT ["uv", "run", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG TARGETPLATFORM
 FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 
 # install uv to run stdio clients (uvx)
-RUN pip install --no-cache-dir uv --platform=$TARGETPLATFORM
+RUN pip install --no-cache-dir uv --platform=$TARGETPLATFORM --no-deps
 
 # install npx to run stdio clients (npx)
 RUN apt-get update && apt-get install -y --no-install-recommends curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 RUN apt-get update && apt-get install -y curl qemu-user-static
 
 # install nodejs
-curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
 
 # install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG TARGETPLATFORM
-FROM --platform=$BUILDPLATFORM python:3.12-bullseye
+FROM --platform=$BUILDPLATFORM python:3.12-slim
 
 # install curl, qemu-user-static
 RUN apt-get update && apt-get install -y curl qemu-user-static
@@ -9,6 +9,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install
 
 # install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN source $HOME/.local/bin/env
 
 COPY pyproject.toml .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@ ARG TARGETPLATFORM
 FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 
 # install uv to run stdio clients (uvx)
-RUN pip install --no-cache-dir uv
+RUN pip install --no-cache-dir uv --platform=$TARGETPLATFORM
 
 # install npx to run stdio clients (npx)
 RUN apt-get update && apt-get install -y --no-install-recommends curl
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y --no-install-recommends nodejs
+
+# install qemu-user-static for multi-platform builds
+RUN apt-get update && apt-get install -y qemu-user-static
     
 COPY pyproject.toml .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,8 @@ RUN apt-get update && apt-get install -y git curl
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
 
 # install uv
-RUN case "$(uname -m)" in \
-        aarch64) ARCH="aarch64" ;; \
-        arm64) ARCH="aarch64" ;; \
-        x86_64) ARCH="x86_64" ;; \
-        *) echo "Unsupported architecture" && exit 1 ;; \
-    esac && \
-    curl -LsSf https://github.com/astral-sh/uv/releases/download/0.5.20/uv-${ARCH}-unknown-linux-gnu.tar.gz | tar -xz && \
-    mv uv /usr/local/bin/uv && \
-    chmod +x /usr/local/bin/uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
 
 COPY pyproject.toml .
 
@@ -31,4 +24,4 @@ COPY mcp_bridge mcp_bridge
 EXPOSE 8000
 
 WORKDIR /mcp_bridge
-ENTRYPOINT ["uv", "run", "main.py"]
+ENTRYPOINT ["/root/.local/bin/uv", "run", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY pyproject.toml .
 COPY mcp_bridge/__init__.py mcp_bridge/__init__.py
 COPY README.md README.md
 
-RUN uv sync
+RUN $HOME/.local/bin/uv sync
 
 COPY mcp_bridge mcp_bridge
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG TARGETPLATFORM
-FROM --platform=$TARGETPLATFORM python:3.12-slim
+FROM python:3.12-bullseye
 
 # install curl
 RUN apt-get update && apt-get install -y git curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG TARGETPLATFORM
-FROM --platform=$BUILDPLATFORM python:3.12-bullseye
-
-# install curl, qemu-user-static
+FROM --platform=$BUILDPLATFORM python:3.12-slim
+USER root
+# install curl
 RUN apt-get update && apt-get install -y git curl
 
 # install nodejs
@@ -24,4 +24,4 @@ COPY mcp_bridge mcp_bridge
 EXPOSE 8000
 
 WORKDIR /mcp_bridge
-ENTRYPOINT ["uv", "run", "main.py"]
+ENTRYPOINT ["/root/.local/bin/uv", "run", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG TARGETPLATFORM
-FROM --platform=$BUILDPLATFORM python:3.12-slim
+FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 
 # install curl, qemu-user-static
-RUN apt-get update && apt-get install -y curl qemu-user-static
+RUN apt-get update && apt-get install -y git curl
 
 # install nodejs
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG TARGETPLATFORM
 FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 
 # install uv to run stdio clients (uvx)
-RUN pip install --no-cache-dir uv --platform=$TARGETPLATFORM --no-deps
+RUN pip install --no-cache-dir uv --platform=$TARGETPLATFORM --no-deps --target /usr/local/lib/python3.12/site-packages
 
 # install npx to run stdio clients (npx)
 RUN apt-get update && apt-get install -y --no-install-recommends curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install
 
 # install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH=$HOME/.local/bin:$PATH
+RUN export PATH=/root/.local/bin:$PATH
 
 COPY pyproject.toml .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12-bullseye
+ARG TARGETPLATFORM
+FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 
 # install uv to run stdio clients (uvx)
 RUN pip install --no-cache-dir uv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,16 @@
 ARG TARGETPLATFORM
 FROM --platform=$BUILDPLATFORM python:3.12-bullseye
 
-# install uv to run stdio clients (uvx)
-RUN pip install --no-cache-dir uv --platform=$TARGETPLATFORM --no-deps --target /usr/local/lib/python3.12/site-packages
+# install uv, curl, nodejs, and qemu-user-static
+RUN apt-get update && apt-get install -y --no-install-recommends uv curl qemu-user-static && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs
 
-# install npx to run stdio clients (npx)
-RUN apt-get update && apt-get install -y --no-install-recommends curl
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get install -y --no-install-recommends nodejs
-
-# install qemu-user-static for multi-platform builds
-RUN apt-get update && apt-get install -y qemu-user-static
-    
 COPY pyproject.toml .
 
 ## FOR GHCR BUILD PIPELINE
 COPY mcp_bridge/__init__.py mcp_bridge/__init__.py
 COPY README.md README.md
-
 
 RUN uv sync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,15 @@ RUN apt-get update && apt-get install -y git curl
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
 
 # install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH=/root/.local/bin:$PATH
+RUN case "$(uname -m)" in \
+        aarch64) ARCH="aarch64" ;; \
+        arm64) ARCH="aarch64" ;; \
+        x86_64) ARCH="x86_64" ;; \
+        *) echo "Unsupported architecture" && exit 1 ;; \
+    esac && \
+    curl -LsSf https://github.com/astral-sh/uv/releases/download/0.5.20/uv-${ARCH}-unknown-linux-gnu.tar.gz | tar -xz && \
+    mv uv /usr/local/bin/uv && \
+    chmod +x /usr/local/bin/uv
 
 COPY pyproject.toml .
 
@@ -24,4 +31,4 @@ COPY mcp_bridge mcp_bridge
 EXPOSE 8000
 
 WORKDIR /mcp_bridge
-ENTRYPOINT ["/root/.local/bin/uv", "run", "main.py"]
+ENTRYPOINT ["uv", "run", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG TARGETPLATFORM
-FROM --platform=$BUILDPLATFORM python:3.12-slim
+FROM --platform=$TARGETPLATFORM python:3.12-slim
 USER root
 # install curl
 RUN apt-get update && apt-get install -y git curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,13 @@ RUN apt-get update && apt-get install -y git curl
 # install nodejs
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y --no-install-recommends nodejs
 
-# install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+# install uv with awareness of target architecture
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_ARCH=aarch64 sh; \
+    else \
+      curl -LsSf https://astral.sh/uv/install.sh | sh; \
+    fi
 ENV PATH=/root/.local/bin:$PATH
 
 COPY pyproject.toml .


### PR DESCRIPTION
Add a new GitHub workflow to build and push Docker images to GitHub Container Registry on every branch push.

* **New Workflow**: Add `.github/workflows/docker-image.yml` to build and push Docker images with platform support for `arm64` and `amd64`.
* **Dockerfile Update**: Modify `Dockerfile` to support multi-platform builds by adding `ARG TARGETPLATFORM` and `--platform=$BUILDPLATFORM` to the `FROM` instruction.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eric2788/MCP-Bridge/pull/1?shareId=6c3014ff-e178-4dcc-9802-bfeaa1a46354).